### PR TITLE
elsevier: use sftp from spider

### DIFF
--- a/hepcrawl/spiders/s3_elsevier_spider.py
+++ b/hepcrawl/spiders/s3_elsevier_spider.py
@@ -136,7 +136,7 @@ class S3ElsevierSpider(Spider):
         self.ftp_user = ftp_user
         self.ftp_password = ftp_password
         self.ftp_dir = ftp_dir
-        self.ftp_post = ftp_port
+        self.ftp_port = ftp_port
 
     def start_requests(self):
         """List selected folder on locally mounted remote SFTP and yield new tar files."""
@@ -176,7 +176,7 @@ class S3ElsevierSpider(Spider):
 
         # Connect to the ftp server
         with pysftp.Connection(self.ftp_host, username=self.ftp_user, password=self.ftp_password,
-                               port=self.ftp_port,cnopts=cnopts) as ftp:
+                               port=self.ftp_port, cnopts=cnopts) as ftp:
             self.log("SFTP connection established.", logging.INFO)
 
             # change dir to remote folder.

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ install_requires = [
     # TODO: unpin once they support wheel building again
     'scrapyd==1.2.0',
     'scrapyd-client==1.0.1',
-    'six==1.11.0',
+    'six==1.12.0',
     'requests==2.20.0',
     'celery==3.1.26.post2',
     'redis==2.10.6',
@@ -46,6 +46,7 @@ install_requires = [
     'LinkHeader==0.4.3',
     'furl==0.5.6',
     'ftputil==3.3.1',
+    'pysftp==0.2.9',
     'python-dateutil==2.6.1',
 ]
 

--- a/tests/responses/__init__.py
+++ b/tests/responses/__init__.py
@@ -24,7 +24,6 @@ def fake_response_from_file(file_name, url='http://www.example.com', response_ty
 
     :returns: A scrapy HTTP response which can be used for unittesting.
     """
-    meta = {}
     request = Request(url=url)
 
     if not file_name[0] == '/':
@@ -36,7 +35,7 @@ def fake_response_from_file(file_name, url='http://www.example.com', response_ty
     file_content = open(file_path, 'r').read()
 
     response = response_type(
-        url=url,
+        url=file_path,
         request=request,
         body=file_content,
         **{'encoding': 'utf-8'}

--- a/tests/test_s3_elsevier.py
+++ b/tests/test_s3_elsevier.py
@@ -38,8 +38,7 @@ def results():
 
                 fake_response = fake_response_from_file(
                     path.join('s3_elsevier', test_file),
-                    response_type=TextResponse,
-                    url='http://example.com/' + test_file
+                    response_type=TextResponse
                 )
                 fake_response.meta['local_filename'] = path.join(download_dir, test_file)
 


### PR DESCRIPTION
Instead using sshfs to mount Elsevier SFTP have the spider connect to the server and download the new packages. This seems to be a way more reliable method.

This PR also adds the possibility to test this feature by adding an `sftp` container.

Steps for testing:

1. First run the sftp container, the spider will connect to this. (if the scrapy runs outside of docker, the `sftp` host should be added to the hosts file pointing to localhost). Make sure that `$DOCKER_DATA/packages` directory exists and contains a couple Elsevier packages.
`docker-compose -f docker-compose.yml -f docker-compose.test.yml up -d sftp`
2. When running scrapyd make sure to set `HEPCRAWL_BASE_WORKING_DIR` env variable to a path that is accessible by scrapyd and celery as well. (In docker devenv this is done automatically)
3. run `scrapyd-deploy` in hepcrawl folder (not sure it's needed) 
4. In `scoap3 shell` execute the following:
```python
from inspire_crawler.tasks import schedule_crawl
schedule_crawl(spider='Elsevier', workflow='articles_upload')
```
This will schedule an Elsevier harvest, which will download the files from the sftp container, unpack them, and schedule article upload workflows.
