### PR TITLE
Elsevier parser: added address-line value for affiliation

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -8,32 +8,41 @@ on:
       - master
   release:
     types: [published]
-    
+
 jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      
-      - name: Install Python 2.7
-        uses: actions/setup-python@v3
+      - name: Checkout
+        uses: actions/checkout@v2
         with:
-          python-version: 2.7
-      
-      - name: Install dependencies
-        run: |
-          python --version
-          python -m pip install --upgrade pip setuptools wheel
-          pip install --no-cache-dir typing==3.7.4.1
-          pip install --ignore-installed -r requirements.txt -e .[tests,docs]
-      
+          fetch-depth: 0
+
+      - name: Build and Run Tests in Docker
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          dockerfile: Dockerfile
+          tags: tests_image
+          build-args: |
+            PYTHON_VERSION=2.7
+
       - name: Run tests with pytest and generate report
-        run: coverage run -m pytest
-      
+        run: >
+          docker run
+          --name tests_container
+          --entrypoint pytest
+          --volume $(pwd):/app
+          tests_image
+          tests
+          --cov=./
+          --cov-report=xml
+
       - name: Upload Coverage to Codecov
         uses: codecov/codecov-action@v2
-      
+
       - name: Build and push
+        if: ${{ github.event_name == 'push'}}
         id: build
         uses: cern-sis/gh-workflows/.github/actions/docker-build@v5.5.0
         with:

--- a/hepcrawl/extractors/s3_elsevier_parser.py
+++ b/hepcrawl/extractors/s3_elsevier_parser.py
@@ -161,7 +161,7 @@ class S3ElsevierParser(object):
         for aff_id in ref_ids:
             ce_affiliation = author_group.xpath("//affiliation[@id='" + aff_id + "']")
             if ce_affiliation.xpath(".//affiliation"):
-                aff = ce_affiliation.xpath(".//*[self::organization or self::city or self::country]/text()")
+                aff = ce_affiliation.xpath(".//*[self::organization or self::city or self::country or self::address-line]/text()")
                 affiliations_by_id.append(", ".join(aff.extract()))
             elif ce_affiliation:
                 aff = ce_affiliation.xpath("./textfn/text()").extract_first()


### PR DESCRIPTION
* The value of affiliation was not parsed, since it was missing address-line path.
* The affiliation was parsed as empty value, that's why the default value 'HUMAN CHECK' was added.
* ref: https://github.com/cern-sis/issues-scoap3/issues/188